### PR TITLE
Add comprehensive logging utilities for ESPnet3 experiments

### DIFF
--- a/egs3/europarl/s2t1/conf/default.yaml
+++ b/egs3/europarl/s2t1/conf/default.yaml
@@ -3,6 +3,30 @@ num_device: 1
 seed: 2024
 task:
 
+logging:
+  level: INFO
+  path:
+  stdout: true
+  overwrite: true
+  log_all_env_vars: false
+  env_keys:
+    - CUDA_VISIBLE_DEVICES
+    - SLURM_JOB_ID
+    - SLURM_PROCID
+    - SLURM_LOCALID
+    - SLURM_NODEID
+    - WORLD_SIZE
+    - RANK
+    - LOCAL_RANK
+    - NODE_RANK
+    - MASTER_ADDR
+    - MASTER_PORT
+    - OMP_NUM_THREADS
+    - MKL_NUM_THREADS
+    - PYTHONPATH
+    - PL_GLOBAL_SEED
+    - PL_TORCH_DISTRIBUTED_BACKEND
+
 parallel:
   env: local
   n_workers: 1

--- a/egs3/europarl/s2t1/conf/inference_beam1.yaml
+++ b/egs3/europarl/s2t1/conf/inference_beam1.yaml
@@ -2,6 +2,11 @@ recipedir: .
 expdir: exp/train
 decode_dir: ${expdir}/decode
 
+logging:
+  path: ${expdir}/logs/evaluate.log
+  stdout: true
+  overwrite: true
+
 model:
   _target_: espnet2.bin.asr_inference.Speech2Text
   asr_train_config: ${expdir}/config.yaml

--- a/egs3/europarl/s2t1/conf/owsm_finetune.yaml
+++ b/egs3/europarl/s2t1/conf/owsm_finetune.yaml
@@ -10,6 +10,11 @@ defaults:
   - dataset.yaml
   - conf/default.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+  stdout: true
+  overwrite: true
+
 parallel:
   env: slurm
   n_workers: 16

--- a/egs3/europarl/s2t1/conf/owsm_finetune_gpu2.yaml
+++ b/egs3/europarl/s2t1/conf/owsm_finetune_gpu2.yaml
@@ -2,6 +2,9 @@
 defaults:
   - train.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+
 num_device: 2
 
 trainer:

--- a/egs3/europarl/s2t1/evaluate.py
+++ b/egs3/europarl/s2t1/evaluate.py
@@ -1,16 +1,21 @@
 import argparse
+import logging
 import time
-import os
 from pathlib import Path
 
 import torch.nn as nn
-from omegaconf import OmegaConf
 from hydra.utils import instantiate
 
 # from espnet2.bin.asr_inference_ctc import Speech2Text
 from espnet3.inference.inference_runner import InferenceRunner
-from espnet3.utils.config import load_config_with_defaults
 from espnet3.inference.score_runner import ScoreRunner
+from espnet3.utils.config import load_config_with_defaults
+from espnet3.utils.logging import (
+    log_configuration,
+    log_environment_snapshot,
+    log_experiment_directories,
+    setup_logging_from_config,
+)
 
 
 class ASRInferenceRunner(InferenceRunner, nn.Module):
@@ -48,14 +53,13 @@ class ASRInferenceRunner(InferenceRunner, nn.Module):
         return output
 
 
-def run_single_sample_inference(config_path):
-    config = load_config_with_defaults(config_path)
-
+def run_single_sample_inference(config, logger):
     runner = ASRInferenceRunner(
         model_config=config.model,
         dataset_config=config.dataset,
     )
 
+    logger.info("Running debug inference on the first sample of each test set.")
     for test_sets in config.dataset.test:
         test_key = test_sets.name
         dataset = runner.initialize_dataset(test_key)
@@ -63,6 +67,7 @@ def run_single_sample_inference(config_path):
 
         result = runner.run_on_example(test_key, sample)
         for key, val in result.items():
+            logger.info("%s - %s: %s", test_key, key, val["value"])
             print(f"{key}: {val['value']}")
 
 
@@ -82,9 +87,45 @@ def main():
 
     args = parser.parse_args()
 
+    base_config = load_config_with_defaults(args.config)
+
+    _, logging_options = setup_logging_from_config(getattr(base_config, "logging", None))
+    logger = logging.getLogger("espnet3.evaluate")
+
+    if logging_options.get("path"):
+        logger.info("Logging to file: %s", logging_options["path"])
+    else:
+        logger.info("Logging to stdout (no log file path configured)")
+
+    logger.info("Configuration file: %s", Path(args.config).resolve())
+    logger.info("Script arguments: %s", vars(args))
+
+    log_environment_snapshot(
+        logger,
+        env_keys=logging_options.get("env_keys"),
+        log_all_env_vars=logging_options.get("log_all_env_vars", False),
+    )
+
+    log_experiment_directories(
+        logger,
+        expdir=getattr(base_config, "expdir", None),
+        decode_dir=getattr(base_config, "decode_dir", None),
+    )
+
+    log_configuration(logger, base_config)
+    if getattr(base_config, "parallel", None) is not None:
+        log_configuration(logger, base_config.parallel, header="Parallel Configuration")
+
+    if getattr(base_config, "dataset", None) and getattr(base_config.dataset, "test", None):
+        test_names = [ds_conf.name for ds_conf in base_config.dataset.test]
+        logger.info("Configured test sets: %s", test_names)
+
+    if getattr(base_config, "metrics", None):
+        logger.info("Configured metrics: %s", [m._target_ for m in base_config.metrics])
+
     if args.stage in ["decode", "all"]:
         if args.debug_sample:
-            run_single_sample_inference(args.config)
+            run_single_sample_inference(base_config, logger)
         else:
             config = load_config_with_defaults(args.config)
 
@@ -95,8 +136,12 @@ def main():
             )
             test_keys = [ds_conf.name for ds_conf in config.dataset.test]
 
+            logger.info("Starting batched decoding for test sets: %s", test_keys)
+
             for test_key in test_keys:
-                runner.run_on_dataset(test_key, output_dir=f"{config.decode_dir}/{test_key}")
+                output_dir = Path(config.decode_dir) / test_key
+                logger.info("Decoding dataset '%s' into %s", test_key, output_dir)
+                runner.run_on_dataset(test_key, output_dir=str(output_dir))
 
     if args.stage in ["score", "all"]:
         config = load_config_with_defaults(args.config)
@@ -104,13 +149,18 @@ def main():
         results = runner.run()
 
         # Print results summary
+        logger.info("===== Score Summary =====")
         print("\n===== Score Summary =====")
         for metric_name, test_results in results.items():
+            logger.info("Metric: %s", metric_name)
             print(f"Metric: {metric_name}")
             for test_name, scores in test_results.items():
+                logger.info("  [%s]", test_name)
                 print(f"  [{test_name}]")
                 for k, v in scores.items():
+                    logger.info("    %s: %s", k, v)
                     print(f"    {k}: {v}")
+        logger.info("=========================")
         print("=========================")
 
 

--- a/egs3/europarl/s2t1/train.py
+++ b/egs3/europarl/s2t1/train.py
@@ -1,4 +1,6 @@
 import argparse
+import logging
+from pathlib import Path
 
 import lightning as L
 import torch
@@ -8,10 +10,19 @@ from tqdm import tqdm
 from dask.distributed import WorkerPlugin, as_completed, get_worker
 
 from espnet3 import get_espnet_model, save_espnet_config
-from espnet3.utils.config import load_config_with_defaults
 from espnet3.preprocess import train_sentencepiece
 from espnet3.trainer import ESPnetEZLightningTrainer, LitESPnetModel
 from espnet3.parallel import get_client, set_parallel
+from espnet3.utils.config import load_config_with_defaults
+from espnet3.utils.logging import (
+    log_configuration,
+    log_dataset_snapshot,
+    log_environment_snapshot,
+    log_experiment_directories,
+    log_model_summary,
+    log_trainer_summary,
+    setup_logging_from_config,
+)
 
 
 class TokenizerPlugin(WorkerPlugin):
@@ -69,9 +80,37 @@ def main():
     # Load config
     config = load_config_with_defaults(args.config)
 
+    _, logging_options = setup_logging_from_config(getattr(config, "logging", None))
+    logger = logging.getLogger("espnet3.train")
+
+    if logging_options.get("path"):
+        logger.info("Logging to file: %s", logging_options["path"])
+    else:
+        logger.info("Logging to stdout (no log file path configured)")
+
+    logger.info("Configuration file: %s", Path(args.config).resolve())
+    logger.info("Script arguments: %s", vars(args))
+
+    log_environment_snapshot(
+        logger,
+        env_keys=logging_options.get("env_keys"),
+        log_all_env_vars=logging_options.get("log_all_env_vars", False),
+    )
+
+    log_experiment_directories(
+        logger,
+        expdir=getattr(config, "expdir", None),
+        statsdir=getattr(config, "statsdir", None),
+    )
+
+    log_configuration(logger, config)
+    if getattr(config, "parallel", None) is not None:
+        log_configuration(logger, config.parallel, header="Parallel Configuration")
+
     if args.train_tokenizer:
-        print("==> Training tokenizer...")
+        logger.info("Training tokenizer before starting model training.")
         train_tokenizer(config)
+        logger.info("Tokenizer training finished.")
 
     # Set seed
     if getattr(config, "seed", None) is not None:
@@ -82,10 +121,14 @@ def main():
     normalize = None
     normalize_conf = None
     if args.collect_stats:
+        logger.info("Collecting normalization statistics before training.")
         if "normalize" in config.model:
             normalize = config.model.pop("normalize")
+            logger.info("Temporarily removed 'normalize' module for stats collection.")
         if "normalize_conf" in config.model:
             normalize_conf = config.model.pop("normalize_conf")
+            logger.info(
+                "Temporarily removed 'normalize_conf' for stats collection.")
 
     task = getattr(config, "task", None)
     model = get_espnet_model(task, config.model) if task else instantiate(config.model)
@@ -93,6 +136,13 @@ def main():
 
     # Float32 precision
     torch.set_float32_matmul_precision("high")
+
+    log_model_summary(logger, lit_model)
+    log_dataset_snapshot(
+        logger,
+        train_dataset=lit_model.train_dataset,
+        valid_dataset=lit_model.valid_dataset,
+    )
 
     # Setup trainer
     trainer = ESPnetEZLightningTrainer(
@@ -102,19 +152,31 @@ def main():
         best_model_criterion=config.best_model_criterion,
     )
 
+    log_trainer_summary(logger, trainer)
+
     if args.collect_stats:
-        print("==> Running collect_stats...", flush=True)
+        logger.info("Running collect_stats using current trainer configuration.")
         trainer.collect_stats()
+        logger.info("collect_stats finished.")
 
         if normalize is not None:
             config.model["normalize"] = normalize
+            logger.info("Restored 'normalize' module after stats collection.")
         if normalize_conf is not None:
             config.model["normalize_conf"] = normalize_conf
+            logger.info("Restored 'normalize_conf' after stats collection.")
 
         model = (
             get_espnet_model(task, config.model) if task else instantiate(config.model)
         )
         lit_model = LitESPnetModel(model, config)
+
+        log_model_summary(logger, lit_model)
+        log_dataset_snapshot(
+            logger,
+            train_dataset=lit_model.train_dataset,
+            valid_dataset=lit_model.valid_dataset,
+        )
 
         trainer = ESPnetEZLightningTrainer(
             model=lit_model,
@@ -123,11 +185,18 @@ def main():
             best_model_criterion=config.best_model_criterion,
         )
 
+        log_trainer_summary(logger, trainer)
+
     # save espnet-like config for inference
     if task:
         save_espnet_config(task, config, config.expdir)
+        logger.info("Saved ESPnet-compatible config to %s", Path(config.expdir) / "config.yaml")
 
     fit_params = {} if not hasattr(config, "fit") else config.fit
+    if fit_params:
+        logger.info("Starting training with fit parameters: %s", dict(fit_params))
+    else:
+        logger.info("Starting training with default fit parameters.")
     trainer.fit(**fit_params)
 
 

--- a/egs3/librispeech_100/asr1/conf/default.yaml
+++ b/egs3/librispeech_100/asr1/conf/default.yaml
@@ -4,6 +4,30 @@ num_nodes: 1
 seed: 2024
 task:
 
+logging:
+  level: INFO
+  path:
+  stdout: true
+  overwrite: true
+  log_all_env_vars: false
+  env_keys:
+    - CUDA_VISIBLE_DEVICES
+    - SLURM_JOB_ID
+    - SLURM_PROCID
+    - SLURM_LOCALID
+    - SLURM_NODEID
+    - WORLD_SIZE
+    - RANK
+    - LOCAL_RANK
+    - NODE_RANK
+    - MASTER_ADDR
+    - MASTER_PORT
+    - OMP_NUM_THREADS
+    - MKL_NUM_THREADS
+    - PYTHONPATH
+    - PL_GLOBAL_SEED
+    - PL_TORCH_DISTRIBUTED_BACKEND
+
 parallel:
   env: local
   n_workers: 1

--- a/egs3/librispeech_100/asr1/conf/inference_beam1.yaml
+++ b/egs3/librispeech_100/asr1/conf/inference_beam1.yaml
@@ -5,6 +5,11 @@ decode_dir: ${expdir}/decode
 defaults:
   - dataset.yaml
 
+logging:
+  path: ${expdir}/logs/evaluate.log
+  stdout: true
+  overwrite: true
+
 model:
   _target_: espnet2.bin.asr_inference.Speech2Text
   asr_train_config: ${expdir}/config.yaml

--- a/egs3/librispeech_100/asr1/conf/train_asr_e_branchformer_size256_mlp1024_linear1024_e12_mactrue_edrop0.0_ddrop0.0.yaml
+++ b/egs3/librispeech_100/asr1/conf/train_asr_e_branchformer_size256_mlp1024_linear1024_e12_mactrue_edrop0.0_ddrop0.0.yaml
@@ -11,6 +11,11 @@ defaults:
   - dataset.yaml
   - conf/default.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+  stdout: true
+  overwrite: true
+
 parallel:
   env: slurm
   n_workers: 16

--- a/egs3/librispeech_100/asr1/conf/train_ctc.yaml
+++ b/egs3/librispeech_100/asr1/conf/train_ctc.yaml
@@ -11,6 +11,11 @@ defaults:
   - dataset.yaml
   - conf/default.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+  stdout: true
+  overwrite: true
+
 parallel:
   env: slurm
   n_workers: 16

--- a/egs3/librispeech_100/asr1/conf/train_debug.yaml
+++ b/egs3/librispeech_100/asr1/conf/train_debug.yaml
@@ -11,6 +11,11 @@ defaults:
   - dataset.yaml
   - conf/default.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+  stdout: true
+  overwrite: true
+
 
 parallel:
   env: slurm

--- a/egs3/librispeech_100/asr1/conf/train_gpu2.yaml
+++ b/egs3/librispeech_100/asr1/conf/train_gpu2.yaml
@@ -2,6 +2,9 @@
 defaults:
   - train.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+
 num_device: 2
 
 trainer:

--- a/egs3/librispeech_100/asr1/evaluate.py
+++ b/egs3/librispeech_100/asr1/evaluate.py
@@ -1,16 +1,21 @@
 import argparse
+import logging
 import time
-import os
 from pathlib import Path
 
 import torch.nn as nn
-from omegaconf import OmegaConf
 from hydra.utils import instantiate
 
 # from espnet2.bin.asr_inference_ctc import Speech2Text
 from espnet3.inference.inference_runner import InferenceRunner
-from espnet3.utils.config import load_config_with_defaults
 from espnet3.inference.score_runner import ScoreRunner
+from espnet3.utils.config import load_config_with_defaults
+from espnet3.utils.logging import (
+    log_configuration,
+    log_environment_snapshot,
+    log_experiment_directories,
+    setup_logging_from_config,
+)
 
 
 
@@ -48,14 +53,13 @@ class ASRInferenceRunner(InferenceRunner, nn.Module):
         return output
 
 
-def run_single_sample_inference(config_path):
-    config = load_config_with_defaults(config_path)
-
+def run_single_sample_inference(config, logger):
     runner = ASRInferenceRunner(
         model_config=config.model,
         dataset_config=config.dataset,
     )
 
+    logger.info("Running debug inference on the first sample of each test set.")
     for test_sets in config.dataset.test:
         test_key = test_sets.name
         dataset = runner.initialize_dataset(test_key)
@@ -63,6 +67,7 @@ def run_single_sample_inference(config_path):
 
         result = runner.run_on_example(test_key, sample)
         for key, val in result.items():
+            logger.info("%s - %s: %s", test_key, key, val["value"])
             print(f"{key}: {val['value']}")
 
 
@@ -82,9 +87,45 @@ def main():
 
     args = parser.parse_args()
 
+    base_config = load_config_with_defaults(args.config)
+
+    _, logging_options = setup_logging_from_config(getattr(base_config, "logging", None))
+    logger = logging.getLogger("espnet3.evaluate")
+
+    if logging_options.get("path"):
+        logger.info("Logging to file: %s", logging_options["path"])
+    else:
+        logger.info("Logging to stdout (no log file path configured)")
+
+    logger.info("Configuration file: %s", Path(args.config).resolve())
+    logger.info("Script arguments: %s", vars(args))
+
+    log_environment_snapshot(
+        logger,
+        env_keys=logging_options.get("env_keys"),
+        log_all_env_vars=logging_options.get("log_all_env_vars", False),
+    )
+
+    log_experiment_directories(
+        logger,
+        expdir=getattr(base_config, "expdir", None),
+        decode_dir=getattr(base_config, "decode_dir", None),
+    )
+
+    log_configuration(logger, base_config)
+    if getattr(base_config, "parallel", None) is not None:
+        log_configuration(logger, base_config.parallel, header="Parallel Configuration")
+
+    if getattr(base_config, "dataset", None) and getattr(base_config.dataset, "test", None):
+        test_names = [ds_conf.name for ds_conf in base_config.dataset.test]
+        logger.info("Configured test sets: %s", test_names)
+
+    if getattr(base_config, "metrics", None):
+        logger.info("Configured metrics: %s", [m._target_ for m in base_config.metrics])
+
     if args.stage in ["decode", "all"]:
         if args.debug_sample:
-            run_single_sample_inference(args.config)
+            run_single_sample_inference(base_config, logger)
         else:
             config = load_config_with_defaults(args.config)
 
@@ -95,8 +136,12 @@ def main():
             )
             test_keys = [ds_conf.name for ds_conf in config.dataset.test]
 
+            logger.info("Starting batched decoding for test sets: %s", test_keys)
+
             for test_key in test_keys:
-                runner.run_on_dataset(test_key, output_dir=f"{config.decode_dir}/{test_key}")
+                output_dir = Path(config.decode_dir) / test_key
+                logger.info("Decoding dataset '%s' into %s", test_key, output_dir)
+                runner.run_on_dataset(test_key, output_dir=str(output_dir))
 
     if args.stage in ["score", "all"]:
         config = load_config_with_defaults(args.config)
@@ -104,13 +149,18 @@ def main():
         results = runner.run()
 
         # Print results summary
+        logger.info("===== Score Summary =====")
         print("\n===== Score Summary =====")
         for metric_name, test_results in results.items():
+            logger.info("Metric: %s", metric_name)
             print(f"Metric: {metric_name}")
             for test_name, scores in test_results.items():
+                logger.info("  [%s]", test_name)
                 print(f"  [{test_name}]")
                 for k, v in scores.items():
+                    logger.info("    %s: %s", k, v)
                     print(f"    {k}: {v}")
+        logger.info("=========================")
         print("=========================")
 
 

--- a/egs3/librispeech_100/asr1/train.py
+++ b/egs3/librispeech_100/asr1/train.py
@@ -1,19 +1,25 @@
 import argparse
-import copy
-import os
+import logging
 from pathlib import Path
 
 import lightning as L
-import numpy as np
 import torch
 from hydra.utils import instantiate
-from omegaconf import OmegaConf
 from tqdm import tqdm
 
 from espnet3 import get_espnet_model, save_espnet_config
-from espnet3.utils.config import load_config_with_defaults
 from espnet3.preprocess import train_sentencepiece
 from espnet3.trainer import ESPnetEZLightningTrainer, LitESPnetModel
+from espnet3.utils.config import load_config_with_defaults
+from espnet3.utils.logging import (
+    log_configuration,
+    log_dataset_snapshot,
+    log_environment_snapshot,
+    log_experiment_directories,
+    log_model_summary,
+    log_trainer_summary,
+    setup_logging_from_config,
+)
 
 
 def train_tokenizer(config):
@@ -49,9 +55,35 @@ def main():
     # Load config
     config = load_config_with_defaults(args.config)
 
+    _, logging_options = setup_logging_from_config(getattr(config, "logging", None))
+    logger = logging.getLogger("espnet3.train")
+
+    if logging_options.get("path"):
+        logger.info("Logging to file: %s", logging_options["path"])
+    else:
+        logger.info("Logging to stdout (no log file path configured)")
+
+    logger.info("Configuration file: %s", Path(args.config).resolve())
+    logger.info("Script arguments: %s", vars(args))
+
+    log_environment_snapshot(
+        logger,
+        env_keys=logging_options.get("env_keys"),
+        log_all_env_vars=logging_options.get("log_all_env_vars", False),
+    )
+
+    log_experiment_directories(
+        logger,
+        expdir=getattr(config, "expdir", None),
+        statsdir=getattr(config, "statsdir", None),
+    )
+
+    log_configuration(logger, config)
+
     if args.train_tokenizer:
-        print("==> Training tokenizer...")
+        logger.info("Training tokenizer before starting model training.")
         train_tokenizer(config)
+        logger.info("Tokenizer training finished.")
 
     # Set seed
     if getattr(config, "seed", None) is not None:
@@ -62,10 +94,14 @@ def main():
     normalize = None
     normalize_conf = None
     if args.collect_stats:
+        logger.info("Collecting normalization statistics before training.")
         if "normalize" in config.model:
             normalize = config.model.pop("normalize")
+            logger.info("Temporarily removed 'normalize' module for stats collection.")
         if "normalize_conf" in config.model:
             normalize_conf = config.model.pop("normalize_conf")
+            logger.info(
+                "Temporarily removed 'normalize_conf' for stats collection.")
 
     task = getattr(config, "task", None)
     model = get_espnet_model(task, config.model) if task else instantiate(config.model)
@@ -73,6 +109,13 @@ def main():
 
     # Float32 precision
     torch.set_float32_matmul_precision("high")
+
+    log_model_summary(logger, lit_model)
+    log_dataset_snapshot(
+        logger,
+        train_dataset=lit_model.train_dataset,
+        valid_dataset=lit_model.valid_dataset,
+    )
 
     # Setup trainer
     trainer = ESPnetEZLightningTrainer(
@@ -82,19 +125,31 @@ def main():
         best_model_criterion=config.best_model_criterion,
     )
 
+    log_trainer_summary(logger, trainer)
+
     if args.collect_stats:
-        print("==> Running collect_stats...", flush=True)
+        logger.info("Running collect_stats using current trainer configuration.")
         trainer.collect_stats()
+        logger.info("collect_stats finished.")
 
         if normalize is not None:
             config.model["normalize"] = normalize
+            logger.info("Restored 'normalize' module after stats collection.")
         if normalize_conf is not None:
             config.model["normalize_conf"] = normalize_conf
+            logger.info("Restored 'normalize_conf' after stats collection.")
 
         model = (
             get_espnet_model(task, config.model) if task else instantiate(config.model)
         )
         lit_model = LitESPnetModel(model, config)
+
+        log_model_summary(logger, lit_model)
+        log_dataset_snapshot(
+            logger,
+            train_dataset=lit_model.train_dataset,
+            valid_dataset=lit_model.valid_dataset,
+        )
 
         trainer = ESPnetEZLightningTrainer(
             model=lit_model,
@@ -103,11 +158,18 @@ def main():
             best_model_criterion=config.best_model_criterion,
         )
 
+        log_trainer_summary(logger, trainer)
+
     # save espnet-like config for inference
     if task:
         save_espnet_config(task, config, config.expdir)
+        logger.info("Saved ESPnet-compatible config to %s", Path(config.expdir) / "config.yaml")
 
     fit_params = {} if not hasattr(config, "fit") else config.fit
+    if fit_params:
+        logger.info("Starting training with fit parameters: %s", dict(fit_params))
+    else:
+        logger.info("Starting training with default fit parameters.")
     trainer.fit(**fit_params)
 
 

--- a/egs3/owsm_preprocessed/s2t1/conf/default.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/default.yaml
@@ -4,6 +4,30 @@ num_nodes: 1
 seed: 2024
 task:
 
+logging:
+  level: INFO
+  path:
+  stdout: true
+  overwrite: true
+  log_all_env_vars: false
+  env_keys:
+    - CUDA_VISIBLE_DEVICES
+    - SLURM_JOB_ID
+    - SLURM_PROCID
+    - SLURM_LOCALID
+    - SLURM_NODEID
+    - WORLD_SIZE
+    - RANK
+    - LOCAL_RANK
+    - NODE_RANK
+    - MASTER_ADDR
+    - MASTER_PORT
+    - OMP_NUM_THREADS
+    - MKL_NUM_THREADS
+    - PYTHONPATH
+    - PL_GLOBAL_SEED
+    - PL_TORCH_DISTRIBUTED_BACKEND
+
 parallel:
   env: local
   n_workers: 1

--- a/egs3/owsm_preprocessed/s2t1/conf/evaluate.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/evaluate.yaml
@@ -2,6 +2,11 @@ recipedir: .
 expdir: exp/node_1_gpu_8
 decode_dir: ${expdir}/decode
 
+logging:
+  path: ${expdir}/logs/evaluate.log
+  stdout: true
+  overwrite: true
+
 model:
   _target_: espnet2.bin.asr_inference.Speech2Text
   asr_train_config: ${expdir}/config.yaml

--- a/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu1.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu1.yaml
@@ -11,6 +11,11 @@ defaults:
   - dataset.yaml
   - conf/default.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+  stdout: true
+  overwrite: true
+
 parallel:
   env: slurm
   n_workers: 40

--- a/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu2.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu2.yaml
@@ -2,6 +2,9 @@
 defaults:
   - train.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+
 num_nodes: 1
 num_device: 2
 expdir: ${recipedir}/exp/node_${num_nodes}_gpu_${num_device}

--- a/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu4.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/owsm_train_gpu4.yaml
@@ -2,6 +2,9 @@
 defaults:
   - train.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+
 num_nodes: 1
 num_device: 4
 expdir: ${recipedir}/exp/node_${num_nodes}_gpu_${num_device}

--- a/egs3/owsm_preprocessed/s2t1/conf/owsm_train_node_2_gpu2.yaml
+++ b/egs3/owsm_preprocessed/s2t1/conf/owsm_train_node_2_gpu2.yaml
@@ -2,6 +2,9 @@
 defaults:
   - train.yaml
 
+logging:
+  path: ${expdir}/logs/train.log
+
 num_nodes: 2
 num_device: 2
 expdir: ${recipedir}/exp/node_${num_nodes}_gpu_${num_device}

--- a/espnet3/utils/logging.py
+++ b/espnet3/utils/logging.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping
+
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+DEFAULT_LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+DEFAULT_LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+DEFAULT_ENV_KEYS = [
+    "CUDA_VISIBLE_DEVICES",
+    "SLURM_JOB_ID",
+    "SLURM_PROCID",
+    "SLURM_LOCALID",
+    "SLURM_NODEID",
+    "SLURM_STEP_ID",
+    "SLURM_JOB_NAME",
+    "SLURM_JOB_NODELIST",
+    "WORLD_SIZE",
+    "RANK",
+    "LOCAL_RANK",
+    "NODE_RANK",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "PYTHONPATH",
+    "PL_GLOBAL_SEED",
+    "PL_TORCH_DISTRIBUTED_BACKEND",
+]
+
+
+def _coerce_level(level: int | str | None) -> int:
+    if level is None:
+        return logging.INFO
+    if isinstance(level, int):
+        return level
+    if isinstance(level, str):
+        level_upper = level.upper()
+        if level_upper in logging._nameToLevel:  # type: ignore[attr-defined]
+            return logging._nameToLevel[level_upper]  # type: ignore[attr-defined]
+    raise ValueError(f"Invalid logging level: {level}")
+
+
+def _to_dict(config: object | None) -> MutableMapping[str, object]:
+    if config is None:
+        return {}
+    if isinstance(config, DictConfig):
+        return OmegaConf.to_container(config, resolve=True)  # type: ignore[return-value]
+    if isinstance(config, (dict, Mapping)):
+        return dict(config)
+    if isinstance(config, Namespace):
+        return vars(config)
+    raise TypeError(
+        "Logging configuration must be a mapping-like object, "
+        f"got: {type(config)!r}"
+    )
+
+
+def configure_logging(
+    output_path: str | Path | None = None,
+    *,
+    level: int | str | None = None,
+    to_stdout: bool = True,
+    overwrite: bool = True,
+    fmt: str = DEFAULT_LOG_FORMAT,
+    datefmt: str = DEFAULT_LOG_DATE_FORMAT,
+) -> logging.Logger:
+    resolved_level = _coerce_level(level)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(resolved_level)
+
+    # Remove existing handlers so repeated invocations replace configuration.
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    handlers: list[logging.Handler] = []
+    if to_stdout:
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+        handlers.append(stream_handler)
+
+    if output_path:
+        path = Path(output_path).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(
+            path,
+            mode="w" if overwrite else "a",
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+        handlers.append(file_handler)
+
+    if not handlers:
+        # Fallback to stdout if no handler has been configured.
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+        handlers.append(stream_handler)
+
+    for handler in handlers:
+        root_logger.addHandler(handler)
+
+    logging.captureWarnings(True)
+
+    return logging.getLogger("espnet3")
+
+
+def setup_logging_from_config(
+    config: object | None,
+) -> tuple[logging.Logger, MutableMapping[str, object]]:
+    options = {}
+    if config is not None:
+        options = _to_dict(config)
+
+    output_path = (
+        options.get("path")
+        or options.get("output_path")
+        or options.get("file")
+        or options.get("filepath")
+    )
+
+    logger = configure_logging(
+        output_path=output_path,
+        level=options.get("level"),
+        to_stdout=options.get("stdout", True),
+        overwrite=options.get("overwrite", True),
+        fmt=options.get("format", DEFAULT_LOG_FORMAT),
+        datefmt=options.get("date_format", DEFAULT_LOG_DATE_FORMAT),
+    )
+
+    if output_path:
+        options["path"] = str(Path(output_path).expanduser())
+    else:
+        options["path"] = None
+
+    return logger, options
+
+
+def log_environment_snapshot(
+    logger: logging.Logger,
+    *,
+    env_keys: Iterable[str] | None = None,
+    log_all_env_vars: bool = False,
+) -> None:
+    logger.info("===== Environment Snapshot =====")
+    logger.info("Command line: %s", " ".join(sys.argv))
+    logger.info("Current working directory: %s", Path.cwd())
+    logger.info("Python executable: %s", sys.executable)
+    logger.info("Python version: %s", sys.version.replace("\n", " "))
+    try:
+        import platform
+
+        logger.info("Platform: %s", platform.platform())
+    except Exception as exc:  # pragma: no cover - platform failure is unlikely
+        logger.debug("Failed to retrieve platform information: %s", exc)
+
+    try:
+        import torch
+
+        cuda_available = torch.cuda.is_available()
+        cuda_devices = torch.cuda.device_count() if cuda_available else 0
+        logger.info(
+            "PyTorch: version=%s cuda_available=%s num_cuda_devices=%s",
+            torch.__version__,
+            cuda_available,
+            cuda_devices,
+        )
+    except Exception as exc:  # pragma: no cover - torch may be optional in tests
+        logger.debug("PyTorch information unavailable: %s", exc)
+
+    try:
+        import lightning
+
+        logger.info("Lightning: version=%s", lightning.__version__)
+    except Exception as exc:  # pragma: no cover - lightning may be optional in tests
+        logger.debug("Lightning information unavailable: %s", exc)
+
+    if log_all_env_vars:
+        env_items = dict(os.environ)
+        logger.info(
+            "Logging all environment variables (%d entries)...", len(env_items)
+        )
+    else:
+        requested_keys = list(dict.fromkeys((env_keys or []) + DEFAULT_ENV_KEYS))
+        env_items = {
+            key: os.environ[key]
+            for key in requested_keys
+            if key in os.environ
+        }
+        logger.info(
+            "Logging selected environment variables (%d/%d entries found)...",
+            len(env_items),
+            len(requested_keys),
+        )
+
+    if not env_items:
+        logger.info("No matching environment variables were found.")
+        return
+
+    for key in sorted(env_items):
+        logger.info("ENV[%s]=%s", key, env_items[key])
+
+
+def log_configuration(
+    logger: logging.Logger,
+    config: object,
+    *,
+    header: str = "Resolved Configuration",
+) -> None:
+    logger.info("===== %s =====", header)
+
+    if isinstance(config, (DictConfig, ListConfig)):
+        try:
+            config_text = OmegaConf.to_yaml(config, resolve=True)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to convert OmegaConf to YAML: %s", exc)
+            config_text = repr(config)
+    else:
+        config_text = repr(config)
+
+    for line in config_text.splitlines():
+        logger.info("%s", line)
+
+
+def _count_parameters(module) -> tuple[int, int]:
+    try:
+        total = sum(p.numel() for p in module.parameters())
+        trainable = sum(p.numel() for p in module.parameters() if p.requires_grad)
+    except Exception:
+        return 0, 0
+    return total, trainable
+
+
+def log_model_summary(
+    logger: logging.Logger,
+    model,
+    *,
+    header: str = "Model Summary",
+) -> None:
+    logger.info("===== %s =====", header)
+
+    try:  # pragma: no cover - summary import is optional
+        from lightning.pytorch.utilities.model_summary import ModelSummary
+
+        summary = ModelSummary(model, max_depth=2)
+        logger.info("%s", summary)
+    except Exception as exc:
+        logger.warning("Model summary unavailable: %s", exc)
+        logger.info("Model repr: %s", model)
+
+    total_params, trainable_params = _count_parameters(model)
+    if total_params or trainable_params:
+        logger.info(
+            "Parameters: total=%d trainable=%d",
+            total_params,
+            trainable_params,
+        )
+
+    base_model = getattr(model, "model", None)
+    if base_model is not None and base_model is not model:
+        logger.info(
+            "Base model class: %s.%s",
+            base_model.__class__.__module__,
+            base_model.__class__.__qualname__,
+        )
+        base_total, base_trainable = _count_parameters(base_model)
+        if base_total or base_trainable:
+            logger.info(
+                "Base parameters: total=%d trainable=%d",
+                base_total,
+                base_trainable,
+            )
+        logger.info("Base model structure:\n%s", base_model)
+
+
+def log_dataset_snapshot(
+    logger: logging.Logger,
+    *,
+    train_dataset=None,
+    valid_dataset=None,
+) -> None:
+    datasets = [
+        ("train", train_dataset),
+        ("valid", valid_dataset),
+    ]
+    for split, dataset in datasets:
+        if dataset is None:
+            continue
+        logger.info(
+            "%s dataset class: %s.%s",
+            split.capitalize(),
+            dataset.__class__.__module__,
+            dataset.__class__.__qualname__,
+        )
+        try:
+            size = len(dataset)
+        except Exception as exc:
+            logger.warning(
+                "Unable to determine %s dataset size: %s",
+                split,
+                exc,
+            )
+        else:
+            logger.info("%s dataset size: %s", split.capitalize(), size)
+
+
+def _format_callback(callback) -> str:
+    try:
+        return repr(callback)
+    except Exception:
+        return f"<callback {callback.__class__.__module__}.{callback.__class__.__qualname__}>"
+
+
+def log_trainer_summary(
+    logger: logging.Logger,
+    trainer,
+    *,
+    header: str = "Trainer Summary",
+) -> None:
+    trainer_obj = getattr(trainer, "trainer", trainer)
+    logger.info("===== %s =====", header)
+    logger.info(
+        "Trainer class: %s.%s",
+        trainer_obj.__class__.__module__,
+        trainer_obj.__class__.__qualname__,
+    )
+    logger.info("Trainer repr:\n%s", trainer_obj)
+
+    accelerator = getattr(trainer_obj, "accelerator", None)
+    if accelerator is not None:
+        logger.info("Accelerator: %s", accelerator)
+    strategy = getattr(trainer_obj, "strategy", None)
+    if strategy is not None:
+        logger.info("Strategy: %s", strategy)
+    precision = getattr(trainer_obj, "precision", None)
+    if precision is not None:
+        logger.info("Precision: %s", precision)
+
+    default_root_dir = getattr(trainer_obj, "default_root_dir", None)
+    if default_root_dir:
+        logger.info(
+            "Trainer default_root_dir: %s",
+            Path(default_root_dir).expanduser().resolve(),
+        )
+
+    callbacks = list(getattr(trainer_obj, "callbacks", []) or [])
+    if callbacks:
+        logger.info("Registered callbacks (%d):", len(callbacks))
+        for callback in callbacks:
+            logger.info("  %s", _format_callback(callback))
+    else:
+        logger.info("Registered callbacks: none")
+
+    loggers = getattr(trainer_obj, "loggers", None)
+    if loggers:
+        logger.info("Lightning loggers (%d):", len(loggers))
+        for lg in loggers:
+            logger.info("  %s", _format_callback(lg))
+    else:
+        single_logger = getattr(trainer_obj, "logger", None)
+        if single_logger:
+            logger.info("Lightning logger: %s", _format_callback(single_logger))
+        else:
+            logger.info("Lightning logger: none")
+
+    checkpoint_paths = set()
+    for callback in callbacks:
+        dirpath = getattr(callback, "dirpath", None)
+        if dirpath:
+            checkpoint_paths.add(Path(dirpath).expanduser())
+    checkpoint_callback = getattr(trainer_obj, "checkpoint_callback", None)
+    if checkpoint_callback is not None:
+        dirpath = getattr(checkpoint_callback, "dirpath", None)
+        if dirpath:
+            checkpoint_paths.add(Path(dirpath).expanduser())
+
+    if checkpoint_paths:
+        logger.info("Checkpoint directories:")
+        for path in sorted(checkpoint_paths):
+            try:
+                resolved = path.resolve()
+            except FileNotFoundError:
+                resolved = path
+            logger.info("  %s", resolved)
+    elif default_root_dir:
+        fallback = Path(default_root_dir).expanduser() / "checkpoints"
+        logger.info("Checkpoint directory (default): %s", fallback.resolve())
+    else:
+        logger.info("Checkpoint directory: unavailable")
+
+
+def log_experiment_directories(
+    logger: logging.Logger,
+    *,
+    expdir: str | Path | None = None,
+    statsdir: str | Path | None = None,
+    decode_dir: str | Path | None = None,
+) -> None:
+    if expdir:
+        exp_path = Path(expdir).expanduser()
+        logger.info("Experiment directory: %s", exp_path.resolve())
+        logger.info("Experiment checkpoint directory: %s", (exp_path / "checkpoints").resolve())
+    if statsdir:
+        stats_path = Path(statsdir).expanduser()
+        logger.info("Stats directory: %s", stats_path.resolve())
+    if decode_dir:
+        decode_path = Path(decode_dir).expanduser()
+        logger.info("Decode directory: %s", decode_path.resolve())


### PR DESCRIPTION
## Summary
- add a shared logging utility module that configures outputs, records environment details, and summarizes trainers/models for ESPnet3 runs
- integrate the new logging utilities into the example Librispeech, Europarl, and OWSM training/evaluation scripts so that runs record configuration, environment, datasets, and checkpoints
- extend sample training, evaluation, and inference YAMLs with logging blocks to direct output to stdout or experiment log files

## Testing
- python -m pytest -c /tmp/empty.ini espnet/test/espnet3/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68f922f7b8508324aac3cdbc0283392a